### PR TITLE
Fix reference errors in src tags

### DIFF
--- a/derivCalc/html/index.html
+++ b/derivCalc/html/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Calculus Calculator</title>
-    <link rel="stylesheet" href="/derivCalc/css/style.css">
+    <link rel="stylesheet" href="../css/style.css">
   </head>
   <body>
     <div class="calcInput">
@@ -17,7 +17,7 @@
       <label for="Answer">Answer:</label><br>
       <font id="result"></font>
     </div>
-    <script src="/derivCalc/js/calc.js"></script>
+    <script src="../js/calc.js"></script>
   </body>
-  <style src="/derivCalc/css/style.css"></style>
+  <style src="../css/style.css"></style>
 </html>


### PR DESCRIPTION
Downloading a local copy of this repo results in erroneous operations due to improper reference practice. Solved issue by referencing parent directory as `..\<child>` rather than by name.